### PR TITLE
Add Employment Non-Discrimination Act of 2013 and Uniting American Families Act of 2013

### DIFF
--- a/bill-nicknames.csv
+++ b/bill-nicknames.csv
@@ -28,3 +28,6 @@ hr,1947,113,farm bill,House version of the omnibus bill dealing with the Departm
 hr,3102,113,snap,Nutrition Reform and Work Opportunity Act of 2013 with cuts in the SNAP program
 hr,1755,113,enda,Employment Non-Discrimination Act of 2013
 s,815,113,enda,Employment Non-Discrimination Act of 2013
+hr,519,113,uafa,Uniting American Families Act of 2013
+s,296,113,uafa,Uniting American Families Act of 2013
+hr,717,113,uafa,Reuniting Families Act


### PR DESCRIPTION
Both bills came from searches for nicknames in Congress for iOS.

Sources: [ENDA](http://en.wikipedia.org/wiki/Employment_Non-Discrimination_Act#113th_Congress) and [UAFA](http://en.wikipedia.org/wiki/Uniting_American_Families_Act#Legislative_history)
