### PR TITLE
Have Travis run csvlint on demand

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,2 @@
+install: gem install csvlint
+script: csvlint bill-nicknames.csv


### PR DESCRIPTION
Adds a `.travis.yml` that installs the `csvlint` gem and validates the CSV.